### PR TITLE
Add support for a `validate` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ const args = basicArg({
     port: { type: Number, description: 'Port to listen on', default: 25565 },
     online: { type: Boolean, description: 'Whether to run in online mode' },
     path: { type: String, description: 'Path to the server directory', default: '.' }
-  }
+  },
+  // validate (args) { return true } /* optional fn to verify the args before returning them; non-true return value will print help screen */
 })
 // ...
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare module "basic-cli" {
     description?: string;
     default?: any;
   }
+  type Result = Record<string, boolean | string | number>
   // The second argument is the custom arg array if any, otherwise default to `process.argv`  
   export default function(options: {
     name: string,
@@ -14,6 +15,8 @@ declare module "basic-cli" {
     throwOnError?: boolean, // Throw an error instead of calling process.exit() with help screen (default: false)
     errorOnExtra?: boolean, // Throw an error if there are extra arguments (default: false)
     helpCommand?: string, // The -- command for opening the built-in help screen (default: help)
-    options: Option[]
-  }, arguments?: string[])
+    options: Option[],
+    // Return true here if the result is ok, otherwise a string to raise to the user along with help screen
+    validate?: (args: Result) => void | string
+  }, arguments?: string[]): Result
 }

--- a/index.js
+++ b/index.js
@@ -106,7 +106,14 @@ function parse (options, args) {
     return raise(`** Extraneous options: ${extra.join(', ')}`, options)
   }
 
-  return Object.fromEntries(haves)
+  const result = Object.fromEntries(haves)
+
+  if (options.validate) {
+    const ret = options.validate(result)
+    if (ret !== true) raise(ret)
+  }
+
+  return result
 }
 
 module.exports = parse


### PR DESCRIPTION
This allows users to validate the output (and raise the help screen on error) before returning the result arg dict, where it wouldn't be possible to print the help screen again.