### PR TITLE
Add positional arguments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@
 [![Discord](https://img.shields.io/badge/chat-on%20discord-brightgreen.svg)](https://discord.gg/GsEFRM8)
 [![Try it on gitpod](https://img.shields.io/badge/try-on%20gitpod-brightgreen.svg)](https://gitpod.io/#https://github.com/extremeheat/node-basic-args)
 
-
 Basic argument parsing library using yargs-parser with built-in help screen
+
+## Features
+- **Options**: Define flagged arguments (e.g., `--version`) with types (`String`, `Number`, `Boolean`), descriptions, aliases, and defaults.
+- **Positionals**: Define required positional arguments (e.g., `input.txt output.txt`) with names, types, and descriptions using the `positionals` array.
+- **Help Screen**: Automatically generated with positionals, options, and user-defined usage examples.
+- **Boolean Options**: Simply passing a boolean flag (e.g., `--online`) sets it to `true`. No arguments are needed.
+- **Extras**: Extraneous arguments are stored in the `_` property unless `errorOnExtra` is `true`.
+- **Validation**: Optional `validate` function to check parsed arguments before returning.
+- **Preprocessing**: Optional `preprocess` function to modify raw arguments before parsing.
 
 ## Installation
 
@@ -13,78 +21,107 @@ Basic argument parsing library using yargs-parser with built-in help screen
 
 ## Usage
 
-See index.d.ts for API
+See `index.d.ts` for the full API.
 
-#### CommonJS import
+#### CommonJS Import
 
 ```js
 const args = require('basic-args')({
   name: 'basic-args-example',
   version: '1.0.0',
   description: 'A basic example of basic-args',
-  errorOnUnknown: true,
-  options: {
-    version: { type: String, description: 'Version to connect as', alias: 'v' },
-    port: { type: Number, description: 'Port to listen on', default: 25565 },
-    online: { type: Boolean, description: 'Whether to run in online mode' },
-    path: { type: String, description: 'Path to the server directory', default: '.' }
-  }
-})
-
-console.log(args)
-```
-
-After being ran with `node index.js --version 1.16` (or using `-v 1.16` alias) we would get:
-
-```js
-{ version: '1.16.1', port: 25565, online: false, path: '.' }
-```
-
-Please note Boolean options do not need arguments, simply passing them as an argument will resolve
-them to be true. If you want to force an argument, set type to a String to handle yourself.
-
-Extraneous arguments (when not using errorOnExtra) are stored in the `_` index of the output. The nested `_` contains positionals.
-
-### Help screen
-If we run with --help or get a argument error, we see the help screen:
-
-```
-> node example.js --help   
-basic-args-example - v1.0.0
-A basic example of basic-args
-
-Options:
-  --version     Version to connect as
-  --port        Port to listen on  (default: 25565)
-  --online      Whether to run in online mode
-  --path        Path to the server directory  (default: .)
-```
-
-### Custom args
-The second argument is the custom arg array if any, if it's not set, we default to `process.argv`.
-
-```js
-require('basic-args')(options, process.argv)
-```
-
-### ES6 import
-```js
-import basicArg from 'basic-args'
-const args = basicArg({
-  name: 'basic-args-example',
-  version: '1.0.0',
-  description: 'A basic example of basic-args',
-  throwOnError: false, // Throw an error instead of calling process.exit() with help screen (default: false)
-  helpCommand: 'help', // The -- command for opening the built-in help screen (default: help)
   options: {
     version: { type: String, description: 'Version to connect as', alias: 'v' },
     port: { type: Number, description: 'Port to listen on', default: 25565 },
     online: { type: Boolean, description: 'Whether to run in online mode' },
     path: { type: String, description: 'Path to the server directory', default: '.' }
   },
-  // validate (args) { return true } /* optional fn to verify the args before returning them; non-true return value will print help screen */
+  positionals: [
+    { name: 'input', type: String, description: 'Input file path' },
+    { name: 'output', type: String, description: 'Output file path' }
+  ]
 })
-// ...
+
+console.log(args)
+```
+
+Running the above with `basic-args-example input.txt output.txt --version 1.16` (or using `-v 1.16`) yields:
+
+```js
+{ input: 'input.txt', output: 'output.txt', version: '1.16', port: 25565, online: false, path: '.' }
+```
+
+#### Help Screen
+Running with `--help` (or the configured `helpCommand`) displays the help screen:
+
+```
+basic-args-example - v1.0.0
+A basic example of basic-args
+
+Positionals:
+  input     Input file path
+  output    Output file path
+
+Options:
+  --version, -v Version to connect as
+  --port        Port to listen on  (default: 25565)
+  --online      Whether to run in online mode
+  --path        Path to the server directory  (default: .)
+
+Usage:
+  basic-args-example input.txt output.txt --version 1.16  Start server with version 1.16
+  basic-args-example input.txt output.txt --port 8080      Start server on port 8080
+  basic-args-example input.txt output.txt --online        Start server in online mode
+```
+
+### Configuration
+- `name`: Program name (shown in help).
+- `version`: Program version (shown in help).
+- `description`: Program description (shown in help).
+- `options`: Object mapping option names to `{ type, description, alias?, default? }`.
+- `positionals`: Array of `{ name, type, description? }` for required positional arguments.
+- `examples`: Array of strings for usage examples in the help screen.
+- `errorOnExtra`: If `true`, errors on unrecognized options (default: `false`).
+- `throwOnError`: If `true`, throws errors instead of exiting (default: `false`).
+- `helpCommand`: Command to trigger help screen (default: `help`).
+- `preprocess`: Function to preprocess raw arguments.
+- `validate`: Function to validate parsed arguments.
+
+### Notes
+- Positional arguments are required and must match the order and number defined in `positionals`.
+- Extra positional arguments are stored in `_` unless `errorOnExtra` is `true`.
+- Boolean options don’t accept values (e.g., `--online` is `true`, not `--online true`). Use `String` type for custom handling.
+- Use the second argument to pass custom args instead of `process.argv`:
+
+```js
+require('basic-args')(options, ['--version', '1.16'])
+```
+
+#### ES6 Import
+```js
+import basicArg from 'basic-args'
+const args = basicArg({
+  name: 'basic-args-example',
+  version: '1.0.0',
+  description: 'A basic example of basic-args',
+  throwOnError: false,
+  helpCommand: 'help',
+  options: {
+    version: { type: String, description: 'Version to connect as', alias: 'v' },
+    port: { type: Number, description: 'Port to listen on', default: 25565 },
+    online: { type: Boolean, description: 'Whether to run in online mode' },
+    path: { type: String, description: 'Path to the server directory', default: '.' }
+  },
+  positionals: [
+    { name: 'input', type: String, description: 'Input file path' },
+    { name: 'output', type: String, description: 'Output file path' }
+  ],
+  examples: [
+    'basic-args-example input.txt output.txt --version 1.16  Start server with version 1.16',
+    'basic-args-example input.txt output.txt --port 8080      Start server on port 8080',
+    'basic-args-example input.txt output.txt --online        Start server in online mode'
+  ]
+})
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ const args = require('basic-args')({
   positionals: [
     { name: 'input', type: String, description: 'Input file path' },
     { name: 'output', type: String, description: 'Output file path' }
+  ],
+  examples: [
+    'basic-args-example <inputFile> <outputFile> [--version str]',
+    'basic-args-example input.txt output.txt --version 1.16         Start server with version 1.16'
   ]
 })
 
@@ -69,8 +73,7 @@ Options:
 
 Usage:
   basic-args-example input.txt output.txt --version 1.16  Start server with version 1.16
-  basic-args-example input.txt output.txt --port 8080      Start server on port 8080
-  basic-args-example input.txt output.txt --online        Start server in online mode
+  basic-args-example input.txt output.txt --version 1.16         Start server with version 1.16
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@
 Basic argument parsing library using yargs-parser with built-in help screen
 
 ## Features
-- **Options**: Define flagged arguments (e.g., `--version`) with types (`String`, `Number`, `Boolean`), descriptions, aliases, and defaults.
-- **Positionals**: Define required positional arguments (e.g., `input.txt output.txt`) with names, types, and descriptions using the `positionals` array.
-- **Help Screen**: Automatically generated with positionals, options, and user-defined usage examples.
-- **Boolean Options**: Simply passing a boolean flag (e.g., `--online`) sets it to `true`. No arguments are needed.
-- **Extras**: Extraneous arguments are stored in the `_` property unless `errorOnExtra` is `true`.
-- **Validation**: Optional `validate` function to check parsed arguments before returning.
-- **Preprocessing**: Optional `preprocess` function to modify raw arguments before parsing.
+- Flagged arguments (e.g., `--version`) with types, descriptions, aliases, and defaults.
+- Positional arguments
+- Help screen: Automatically generated with positionals, options, and user-defined usage examples.
+- Extraneous arguments are stored in the `_` property unless `errorOnExtra` is `true`.
+- Validation: Optional `validate` hook to check yargs parsed arguments before returning.
+- Preprocessing: Optional `preprocess` hook to modify raw arguments before parsing.
 
 ## Installation
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,33 @@
-declare module "basic-cli" {
+declare module "basic-args" {
   type Option = {
-    type: Boolean | String | Number;
+    type: BooleanConstructor | StringConstructor | NumberConstructor;
     alias?: string;
     description?: string;
     default?: any;
   }
-  type Result = Record<string, boolean | string | number>
-  // The second argument is the custom arg array if any, otherwise default to `process.argv`  
+
+  type Positional = {
+    name: string;
+    type: BooleanConstructor | StringConstructor | NumberConstructor;
+    description?: string;
+  }
+
+  type Result = Record<string, boolean | string | number | { [key: string]: any }>
+
+  // The second argument is the custom arg array if any, otherwise defaults to `process.argv`
   export default function(options: {
-    name: string,
-    version: string,
-    description: string,
-    throwOnError?: boolean, // Throw an error instead of calling process.exit() with help screen (default: false)
-    errorOnExtra?: boolean, // Throw an error if there are extra arguments (default: false)
-    helpCommand?: string, // The -- command for opening the built-in help screen (default: help)
-    options: Record<string, Option>, // Object containing the list of options program takes. See README for doc.
+    name: string;
+    version: string;
+    description: string;
+    throwOnError?: boolean; // Throw an error instead of calling process.exit() with help screen (default: false)
+    errorOnExtra?: boolean; // Throw an error if there are extra arguments (default: false)
+    helpCommand?: string; // The -- command for opening the built-in help screen (default: help)
+    options?: Record<string, Option>; // Object containing the list of options program takes
+    positionals?: Positional[]; // Array of required positional arguments
+    examples?: string[]; // Array of usage example strings for the help screen
     // Pre-process the yargs parsed arguments before basic-args does any handling
-    preprocess(args: object): void
-    // Return true here if the result is ok, otherwise a string to raise to the user along with help screen
-    validate?: (args: Result) => void | string
-  }, arguments?: string[]): Result
+    preprocess?(args: Record<string, any>): void;
+    // Return true if the result is valid, otherwise a string to raise to the user along with help screen
+    validate?(args: Result): true | string;
+  }, args?: string[]): Result
 }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function parse (options, args) {
   const allOptions = new Map()
   const missing = new Set()
   const haves = new Map()
+  const missingPositionals = []
 
   function raise (message) {
     if (options.throwOnError && message) {
@@ -36,24 +37,26 @@ function parse (options, args) {
     let error = `${options.name} - v${options.version}\n`
     error += `${options.description}\n`
 
-    if (options.examples) {
-      error += 'Usage:\n'
-      for (const example of options.examples) {
-        error += `  ${example}\n`
+    // Show positionals if defined
+    if (options.positionals && options.positionals.length) {
+      error += '\nPositionals:\n'
+      for (const pos of options.positionals) {
+        error += `  ${pos.name}\t${pos.description || ''}\n`
       }
     }
 
+    // Show options
     error += '\nOptions:\n'
-    for (const [key, value] of Object.entries(options.options)) {
-      if (Array.isArray(value)) {
-        console.log('\t', key)
-        for (const [k, v] of value.entries()) {
-          const n = k + (v.alias ? `, -${v.alias}` : '')
-          error += `  --${n}\t${v.description}` + (v.default ? `  (default: ${v.default})` : '  ') + '\n'
-        }
-      } else {
-        const n = key + (value.alias ? `, -${value.alias}` : '')
-        error += `  --${n}\t${value.description}` + (value.default ? `  (default: ${value.default})` : '  ') + '\n'
+    for (const [key, value] of Object.entries(options.options || {})) {
+      const n = key + (value.alias ? `, -${value.alias}` : '')
+      error += `  --${n}\t${value.description || ''}` + (value.default !== undefined ? `  (default: ${value.default})` : '  ') + '\n'
+    }
+
+    // Show examples if provided
+    if (options.examples && options.examples.length) {
+      error += '\nUsage:\n'
+      for (const example of options.examples) {
+        error += `  ${example}\n`
       }
     }
 
@@ -68,7 +71,17 @@ function parse (options, args) {
 
   if (ranHelpCommand) return raise()
 
-  for (const [key, value] of Object.entries(options.options)) {
+  // Check for name conflicts between options and positionals
+  const allOptionNames = new Set(Object.keys(options.options || {}))
+  const positionalNames = new Set()
+  for (const pos of options.positionals || []) {
+    if (allOptionNames.has(pos.name)) throw new Error(`Positional argument name "${pos.name}" conflicts with an option name`)
+    if (positionalNames.has(pos.name)) throw new Error(`Duplicate positional argument name: ${pos.name}`)
+    positionalNames.add(pos.name)
+  }
+
+  // Process options
+  for (const [key, value] of Object.entries(options.options || {})) {
     if (allOptions.has(key)) {
       throw new Error(`Duplicate option: ${key}`)
     }
@@ -77,9 +90,8 @@ function parse (options, args) {
 
     if (value.type === Boolean) {
       if (value.default !== undefined) throw Error(`Boolean options cannot have default values (${key})`)
-
       if (V && boolMap[V] === undefined) {
-        return raise(`Invalid value for ${key}, expected boolean. You don't need to put any arguments to use this flag.`, options)
+        return raise(`Invalid value for ${key}, expected boolean. You don't need to put any arguments to use this flag.`)
       }
       haves.set(key, boolMap[V] || V || false)
     } else {
@@ -91,11 +103,11 @@ function parse (options, args) {
         }
       } else {
         if (value.type === Number) {
-          if (isNaN(V)) return raise(`Invalid value for ${key}, expected number`, options)
+          if (isNaN(V)) return raise(`Invalid value for ${key}, expected number`)
           haves.set(key, Number(V))
         } else if (value.type === String) {
           if (typeof V === 'number') haves.set(key, String(V))
-          else if (typeof V !== 'string') return raise(`Invalid value for ${key}, expected a string but got ${typeof V}`, options)
+          else if (typeof V !== 'string') return raise(`Invalid value for ${key}, expected a string but got ${typeof V}`)
           else haves.set(key, V)
         } else {
           throw Error(`Unknown type: ${value.type}, in ${key} - must be Boolean, Number, or String`)
@@ -104,16 +116,53 @@ function parse (options, args) {
     }
   }
 
-  if (missing.size) {
-    const missingList = Array.from(missing).join(', ')
-    return raise(`** Missing required options: ${missingList}`, options)
+  // Process positional arguments
+  if (options.positionals && options.positionals.length) {
+    const positionalArgs = argv._ || []
+    for (const [index, posDef] of options.positionals.entries()) {
+      if (index >= positionalArgs.length) {
+        missingPositionals.push(posDef.name)
+      } else {
+        const value = positionalArgs[index]
+        if (posDef.type === String) {
+          haves.set(posDef.name, String(value))
+        } else if (posDef.type === Number) {
+          if (isNaN(value)) return raise(`Invalid value for positional argument ${posDef.name}, expected number`)
+          haves.set(posDef.name, Number(value))
+        } else if (posDef.type === Boolean) {
+          if (boolMap[value] === undefined) return raise(`Invalid value for positional argument ${posDef.name}, expected boolean`)
+          haves.set(posDef.name, boolMap[value])
+        } else {
+          throw Error(`Unknown type for positional argument: ${posDef.type}`)
+        }
+      }
+    }
+    // Store extra positional arguments in '_'
+    if (positionalArgs.length > options.positionals.length) {
+      haves.set('_', positionalArgs.slice(options.positionals.length))
+    }
+  } else {
+    // If no positionals defined, keep all positional args in '_'
+    if (argv._.length) haves.set('_', argv._)
   }
 
-  const extra = Object.entries(argv).filter((key) => !allOptions.has(key))
-  haves.set('_', Object.fromEntries(extra))
+  // Handle missing items
+  if (missing.size || missingPositionals.length) {
+    let errorMsg = ''
+    if (missing.size) errorMsg += `Missing required options: ${Array.from(missing).join(', ')}`
+    if (missingPositionals.length) {
+      errorMsg += (errorMsg ? '; ' : '') + `Missing required positional arguments: ${missingPositionals.join(', ')}`
+    }
+    return raise(`** ${errorMsg}`)
+  }
 
+  // Handle extra options
+  const extra = Object.entries(argv).filter(([key]) => key !== '_' && !allOptions.has(key))
   if (options.errorOnExtra && extra.length) {
-    return raise(`** Extraneous options: ${extra.join(', ')}`, options)
+    return raise(`** Extraneous options: ${extra.map(([key]) => key).join(', ')}`)
+  }
+  if (extra.length) {
+    haves.set('_', { ...(haves.get('_') || {}), ...Object.fromEntries(extra) })
   }
 
   const result = Object.fromEntries(haves)

--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function parse (options, args) {
           if (boolMap[value] === undefined) return raise(`Invalid value for positional argument ${posDef.name}, expected boolean`)
           haves.set(posDef.name, boolMap[value])
         } else {
-          throw Error(`Unknown type for positional argument: ${posDef.type}`)
+          throw Error(`Unknown type for positional argument '${posDef.name}': ${posDef.type}`)
         }
       }
     }


### PR DESCRIPTION
Via a new `positionals` option:

```ts
  ...
  positionals: [
    { name: 'input', type: String, description: 'Input file path' },
    { name: 'output', type: String, description: 'Output file path' }
  ],
  examples: [
    'basic-args-example input.txt output.txt --version 1.16  Start server with version 1.16',
    ...
  ]
  ...
```
=>
```
basic-args-example - v1.0.0
A basic example of basic-args

Positionals:
  input     Input file path
  output    Output file path

Options:
  --version, -v Version to connect as
...
```

Used as `example input.txt output.txt --version 1.16` which yields `{ input: 'input.txt', output: 'output.txt', version: '1.16', port: 25565, online: false, path: '.' }`